### PR TITLE
Add missing 'repo-token' input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,11 @@
 name: 'Confirm Trello link included on Pull Request'
 description: 'Confirm Trello link included on Pull Request'
 inputs:
-  link-regex: 
+  link-regex:
     description: 'URL to use reg ex search for'
     default: '(https:\/\/trello.com[^\)]*)'
+  repo-token:
+    description: 'GITHUB_TOKEN secret'
 outputs:
   msg:
     description: 'output of action'


### PR DESCRIPTION
Resolve warning displayed in action output:

> Unexpected input(s) 'repo-token', valid inputs are ['link-regex']